### PR TITLE
Fix snapshot migration in updated() — undefined variable, inverted condition, wrong collection

### DIFF
--- a/src/apps/unofficial-ring-connect.groovy
+++ b/src/apps/unofficial-ring-connect.groovy
@@ -1799,11 +1799,13 @@ void periodicMaintenance() {
 
   if (state.snapshots) {
     // Remove old keys from snapshots that aren't enabled anymore
+    List<String> keysToRemove = []
     for (String snapshotDni in state.snapshots.keySet()) {
-      if (state.enabledSnappables.contains(getRingDeviceId(dni))) {
-        state.enabledSnappables.remove(snapshotDni)
+      if (!state.enabledSnappables.contains(getRingDeviceId(snapshotDni))) {
+        keysToRemove.add(snapshotDni)
       }
     }
+    keysToRemove.each { state.snapshots.remove(it) }
   }
 
   for (final setting in settings) {


### PR DESCRIPTION
Fixes #59

## Changes

Three bugs in the snapshot migration block inside `updated()` in `src/apps/unofficial-ring-connect.groovy`:

**Bug 1 — Undefined variable `dni`:** The condition referenced `dni`, which is not defined in this scope. Changed to `snapshotDni` (the loop variable).

**Bug 2 — Inverted condition:** The goal (per the comment) is to remove keys that are *no longer enabled*. Added `!` to the `contains()` check.

**Bug 3 — Wrong collection + ConcurrentModificationException risk:** The original code removed from `state.enabledSnappables` while iterating over `state.snapshots.keySet()`. Fixed to collect keys first, then remove from `state.snapshots`.

## Before

```groovy
if (state.snapshots) {
    for (String snapshotDni in state.snapshots.keySet()) {
      if (state.enabledSnappables.contains(getRingDeviceId(dni))) {
        state.enabledSnappables.remove(snapshotDni)
      }
    }
}
```

## After

```groovy
if (state.snapshots) {
    List<String> keysToRemove = []
    for (String snapshotDni in state.snapshots.keySet()) {
      if (!state.enabledSnappables.contains(getRingDeviceId(snapshotDni))) {
        keysToRemove.add(snapshotDni)
      }
    }
    keysToRemove.each { state.snapshots.remove(it) }
}
```

## Impact

Without this fix, any hub on the beta branch that previously had snapshot polling configured will hit a `MissingPropertyException` in `updated()` the first time they save app settings after upgrading.